### PR TITLE
Build docker container

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -26,10 +26,37 @@ jobs:
       - name: Build
         run: task build:fc
 
-  build-container:
+  build-goreleaser:
     runs-on: ubuntu-24.04
+    outputs:
+      precompiled-binaries: ${{ steps.upload.outputs.artifact-path }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          persist-credentials: true
+      - uses: arduino/setup-task@v2
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Release (dry-run)
+        run: task build:goreleaser
+      - name: Upload precompiled binaries
+        id: upload
+        uses: actions/upload-artifact@v4
+        with:
+          name: goreleaser-dist
+          path: goreleaser-dist
+
+  build-container:
+    runs-on: ubuntu-24.04
+    needs: [build-goreleaser]
+    steps:
+      - uses: actions/checkout@v4
+      - name: Download precompiled binaries
+        uses: actions/download-artifact@v4
+        with:
+          name: goreleaser-dist
+          path: goreleaser-dist
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
       - name: Set up Docker Buildx
@@ -42,25 +69,38 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build multi-arch container
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v6
         with:
           context: .
-          file: ./Dockerfile
+          file: ./docker/package_precompiled.dockerfile
           push: false
           platforms: linux/amd64,linux/arm64
           tags: |
             ghcr.io/luupsystems/globetrotter:latest
             ghcr.io/luupsystems/globetrotter:${{ github.ref_name }}
 
-  build-goreleaser:
-    runs-on: ubuntu-24.04
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-          persist-credentials: true
-      - uses: arduino/setup-task@v2
-        with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-      - name: Release (dry-run)
-        run: task build:goreleaser
+  # build-container:
+  #   runs-on: ubuntu-24.04
+  #   steps:
+  #     - uses: actions/checkout@v4
+  #     - name: Set up QEMU
+  #       uses: docker/setup-qemu-action@v3
+  #     - name: Set up docker buildx
+  #       uses: docker/setup-buildx-action@v3
+  #     - name: Log in to registry
+  #       uses: docker/login-action@v3
+  #       with:
+  #         registry: ghcr.io
+  #         username: ${{ github.actor }}
+  #         password: ${{ secrets.GITHUB_TOKEN }}
+  #
+  #     - name: Build multi-arch container
+  #       uses: docker/build-push-action@v6
+  #       with:
+  #         context: .
+  #         file: ./docker/build_from_source.dockerfile
+  #         push: false
+  #         platforms: linux/amd64,linux/arm64
+  #         tags: |
+  #           ghcr.io/luupsystems/globetrotter:latest
+  #           ghcr.io/luupsystems/globetrotter:${{ github.ref_name }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -21,7 +21,7 @@ jobs:
       - uses: arduino/setup-task@v2
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-          version: "v3.42.1"
+          version: "3.42.1"
       - uses: dtolnay/rust-toolchain@stable
       - uses: romnn/cargo-feature-combinations@main
       - name: Build
@@ -39,7 +39,7 @@ jobs:
       - uses: arduino/setup-task@v2
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-          version: "v3.42.1"
+          version: "3.42.1"
       - name: Release (dry-run)
         run: task build:goreleaser
       - name: Upload precompiled binaries

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -31,15 +31,16 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
+        uses: docker/setup-qemu-action@v3
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
       - name: Log in to registry
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Build multi-arch container
         uses: docker/build-push-action@v4
         with:
@@ -48,8 +49,8 @@ jobs:
           push: false
           platforms: linux/amd64,linux/arm64
           tags: |
-            ghcr.io/${{ github.repository }}/globetrotter:latest
-            ghcr.io/${{ github.repository }}/globetrotter:${{ github.ref_name }}
+            ghcr.io/luupsystems/globetrotter:latest
+            ghcr.io/luupsystems/globetrotter:${{ github.ref_name }}
 
   build-goreleaser:
     runs-on: ubuntu-24.04

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -21,6 +21,7 @@ jobs:
       - uses: arduino/setup-task@v2
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
+          version: "3.42.1"
       - uses: dtolnay/rust-toolchain@stable
       - uses: romnn/cargo-feature-combinations@main
       - name: Build
@@ -38,6 +39,7 @@ jobs:
       - uses: arduino/setup-task@v2
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
+          version: "3.42.1"
       - name: Release (dry-run)
         run: task build:goreleaser
       - name: Upload precompiled binaries

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -21,6 +21,7 @@ jobs:
       - uses: arduino/setup-task@v2
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
+          version: "v3.42.1"
       - uses: dtolnay/rust-toolchain@stable
       - uses: romnn/cargo-feature-combinations@main
       - name: Build
@@ -38,6 +39,7 @@ jobs:
       - uses: arduino/setup-task@v2
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
+          version: "v3.42.1"
       - name: Release (dry-run)
         run: task build:goreleaser
       - name: Upload precompiled binaries

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -21,7 +21,6 @@ jobs:
       - uses: arduino/setup-task@v2
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-          version: "3.42.1"
       - uses: dtolnay/rust-toolchain@stable
       - uses: romnn/cargo-feature-combinations@main
       - name: Build
@@ -39,7 +38,6 @@ jobs:
       - uses: arduino/setup-task@v2
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-          version: "3.42.1"
       - name: Release (dry-run)
         run: task build:goreleaser
       - name: Upload precompiled binaries

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -20,6 +20,7 @@ jobs:
       - uses: arduino/setup-task@v2
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
+          version: "3.42.1"
       - uses: dtolnay/rust-toolchain@stable
       - uses: romnn/cargo-feature-combinations@main
       - name: Lint
@@ -32,6 +33,7 @@ jobs:
       - uses: arduino/setup-task@v2
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
+          version: "3.42.1"
       - uses: Homebrew/actions/setup-homebrew@master
       - uses: dtolnay/rust-toolchain@stable
       - run: brew install cargo-audit
@@ -45,6 +47,7 @@ jobs:
       - uses: arduino/setup-task@v2
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
+          version: "3.42.1"
       - uses: Homebrew/actions/setup-homebrew@master
       - uses: dtolnay/rust-toolchain@stable
       - run: brew install cargo-outdated
@@ -58,6 +61,7 @@ jobs:
       - uses: arduino/setup-task@v2
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
+          version: "3.42.1"
       - uses: Homebrew/actions/setup-homebrew@master
       - uses: dtolnay/rust-toolchain@nightly
       - run: brew install cargo-udeps
@@ -71,6 +75,7 @@ jobs:
       - uses: arduino/setup-task@v2
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
+          version: "3.42.1"
       - uses: Homebrew/actions/setup-homebrew@master
       - uses: dtolnay/rust-toolchain@stable
       - run: brew install typos-cli

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -20,7 +20,6 @@ jobs:
       - uses: arduino/setup-task@v2
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-          version: "3.42.1"
       - uses: dtolnay/rust-toolchain@stable
       - uses: romnn/cargo-feature-combinations@main
       - name: Lint
@@ -33,7 +32,6 @@ jobs:
       - uses: arduino/setup-task@v2
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-          version: "3.42.1"
       - uses: Homebrew/actions/setup-homebrew@master
       - uses: dtolnay/rust-toolchain@stable
       - run: brew install cargo-audit
@@ -47,7 +45,6 @@ jobs:
       - uses: arduino/setup-task@v2
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-          version: "3.42.1"
       - uses: Homebrew/actions/setup-homebrew@master
       - uses: dtolnay/rust-toolchain@stable
       - run: brew install cargo-outdated
@@ -61,7 +58,6 @@ jobs:
       - uses: arduino/setup-task@v2
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-          version: "3.42.1"
       - uses: Homebrew/actions/setup-homebrew@master
       - uses: dtolnay/rust-toolchain@nightly
       - run: brew install cargo-udeps
@@ -75,7 +71,6 @@ jobs:
       - uses: arduino/setup-task@v2
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-          version: "3.42.1"
       - uses: Homebrew/actions/setup-homebrew@master
       - uses: dtolnay/rust-toolchain@stable
       - run: brew install typos-cli

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -20,6 +20,7 @@ jobs:
       - uses: arduino/setup-task@v2
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
+          version: "v3.42.1"
       - uses: dtolnay/rust-toolchain@stable
       - uses: romnn/cargo-feature-combinations@main
       - name: Lint
@@ -32,6 +33,7 @@ jobs:
       - uses: arduino/setup-task@v2
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
+          version: "v3.42.1"
       - uses: Homebrew/actions/setup-homebrew@master
       - uses: dtolnay/rust-toolchain@stable
       - run: brew install cargo-audit
@@ -45,6 +47,7 @@ jobs:
       - uses: arduino/setup-task@v2
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
+          version: "v3.42.1"
       - uses: Homebrew/actions/setup-homebrew@master
       - uses: dtolnay/rust-toolchain@stable
       - run: brew install cargo-outdated
@@ -58,6 +61,7 @@ jobs:
       - uses: arduino/setup-task@v2
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
+          version: "v3.42.1"
       - uses: Homebrew/actions/setup-homebrew@master
       - uses: dtolnay/rust-toolchain@nightly
       - run: brew install cargo-udeps
@@ -71,6 +75,7 @@ jobs:
       - uses: arduino/setup-task@v2
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
+          version: "v3.42.1"
       - uses: Homebrew/actions/setup-homebrew@master
       - uses: dtolnay/rust-toolchain@stable
       - run: brew install typos-cli

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -20,7 +20,7 @@ jobs:
       - uses: arduino/setup-task@v2
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-          version: "v3.42.1"
+          version: "3.42.1"
       - uses: dtolnay/rust-toolchain@stable
       - uses: romnn/cargo-feature-combinations@main
       - name: Lint
@@ -33,7 +33,7 @@ jobs:
       - uses: arduino/setup-task@v2
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-          version: "v3.42.1"
+          version: "3.42.1"
       - uses: Homebrew/actions/setup-homebrew@master
       - uses: dtolnay/rust-toolchain@stable
       - run: brew install cargo-audit
@@ -47,7 +47,7 @@ jobs:
       - uses: arduino/setup-task@v2
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-          version: "v3.42.1"
+          version: "3.42.1"
       - uses: Homebrew/actions/setup-homebrew@master
       - uses: dtolnay/rust-toolchain@stable
       - run: brew install cargo-outdated
@@ -61,7 +61,7 @@ jobs:
       - uses: arduino/setup-task@v2
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-          version: "v3.42.1"
+          version: "3.42.1"
       - uses: Homebrew/actions/setup-homebrew@master
       - uses: dtolnay/rust-toolchain@nightly
       - run: brew install cargo-udeps
@@ -75,7 +75,7 @@ jobs:
       - uses: arduino/setup-task@v2
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-          version: "v3.42.1"
+          version: "3.42.1"
       - uses: Homebrew/actions/setup-homebrew@master
       - uses: dtolnay/rust-toolchain@stable
       - run: brew install typos-cli

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -30,25 +30,25 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
+        uses: docker/setup-qemu-action@v3
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
       - name: Log in to registry
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Build multi-arch container
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v6
         with:
           context: .
           file: ./Dockerfile
           push: true
           platforms: linux/amd64,linux/arm64
           tags: |
-            ghcr.io/${{ github.repository }}/globetrotter:latest
-            ghcr.io/${{ github.repository }}/globetrotter:${{ github.ref_name }}
+            ghcr.io/luupsystems/globetrotter:latest
+            ghcr.io/luupsystems/globetrotter:${{ github.ref_name }}
 
   release:
     runs-on: ubuntu-24.04

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -38,6 +38,7 @@ jobs:
       - uses: arduino/setup-task@v2
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
+          version: "3.42.1"
       - name: Release
         run: task release
         env:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -25,34 +25,11 @@ jobs:
           resolve-versions: true
           publish-delay: 30s
 
-  publish-container:
-    runs-on: ubuntu-24.04
-    steps:
-      - uses: actions/checkout@v4
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-      - name: Log in to registry
-        uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Build multi-arch container
-        uses: docker/build-push-action@v6
-        with:
-          context: .
-          file: ./Dockerfile
-          push: true
-          platforms: linux/amd64,linux/arm64
-          tags: |
-            ghcr.io/luupsystems/globetrotter:latest
-            ghcr.io/luupsystems/globetrotter:${{ github.ref_name }}
-
   release:
     runs-on: ubuntu-24.04
     needs: [tests]
+    outputs:
+      precompiled-binaries: ${{ steps.upload.outputs.artifact-path }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -66,3 +43,65 @@ jobs:
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
           TAP_GITHUB_TOKEN: "${{ secrets.TAP_GITHUB_TOKEN }}"
+      - name: Upload precompiled binaries
+        id: upload
+        uses: actions/upload-artifact@v4
+        with:
+          name: goreleaser-dist
+          path: goreleaser-dist
+
+  publish-container:
+    runs-on: ubuntu-24.04
+    needs: [release]
+    steps:
+      - uses: actions/checkout@v4
+      - name: Download precompiled binaries
+        uses: actions/download-artifact@v4
+        with:
+          name: goreleaser-dist
+          path: goreleaser-dist
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      - name: Set up docker buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Log in to registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build and push multi-arch container
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./docker/build_from_source.dockerfile
+          push: true
+          platforms: linux/amd64,linux/arm64
+          tags: |
+            ghcr.io/luupsystems/globetrotter:latest
+            ghcr.io/luupsystems/globetrotter:${{ github.ref_name }}
+
+  # publish-container:
+  #   runs-on: ubuntu-24.04
+  #   steps:
+  #     - uses: actions/checkout@v4
+  #     - name: Set up QEMU
+  #       uses: docker/setup-qemu-action@v3
+  #     - name: Set up docker buildx
+  #       uses: docker/setup-buildx-action@v3
+  #     - name: Log in to registry
+  #       uses: docker/login-action@v3
+  #       with:
+  #         registry: ghcr.io
+  #         username: ${{ github.actor }}
+  #         password: ${{ secrets.GITHUB_TOKEN }}
+  #     - name: Build and push multi-arch container
+  #       uses: docker/build-push-action@v6
+  #       with:
+  #         context: .
+  #         file: ./docker/build_from_source.dockerfile
+  #         push: true
+  #         platforms: linux/amd64,linux/arm64
+  #         tags: |
+  #           ghcr.io/luupsystems/globetrotter:latest
+  #           ghcr.io/luupsystems/globetrotter:${{ github.ref_name }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -38,6 +38,7 @@ jobs:
       - uses: arduino/setup-task@v2
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
+          version: "v3.42.1"
       - name: Release
         run: task release
         env:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -38,7 +38,7 @@ jobs:
       - uses: arduino/setup-task@v2
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-          version: "v3.42.1"
+          version: "3.42.1"
       - name: Release
         run: task release
         env:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -38,7 +38,6 @@ jobs:
       - uses: arduino/setup-task@v2
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-          version: "3.42.1"
       - name: Release
         run: task release
         env:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -21,7 +21,6 @@ jobs:
       - uses: arduino/setup-task@v2
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-          version: "3.42.1"
       - uses: dtolnay/rust-toolchain@stable
       - uses: romnn/cargo-feature-combinations@main
       - name: Test
@@ -39,7 +38,6 @@ jobs:
       - uses: arduino/setup-task@v2
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-          version: "3.42.1"
       - uses: dtolnay/rust-toolchain@stable
       - uses: romnn/cargo-feature-combinations@main
       - name: Doc-tests

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -21,6 +21,7 @@ jobs:
       - uses: arduino/setup-task@v2
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
+          version: "v3.42.1"
       - uses: dtolnay/rust-toolchain@stable
       - uses: romnn/cargo-feature-combinations@main
       - name: Test
@@ -38,6 +39,7 @@ jobs:
       - uses: arduino/setup-task@v2
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
+          version: "v3.42.1"
       - uses: dtolnay/rust-toolchain@stable
       - uses: romnn/cargo-feature-combinations@main
       - name: Doc-tests

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -21,6 +21,7 @@ jobs:
       - uses: arduino/setup-task@v2
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
+          version: "3.42.1"
       - uses: dtolnay/rust-toolchain@stable
       - uses: romnn/cargo-feature-combinations@main
       - name: Test
@@ -38,6 +39,7 @@ jobs:
       - uses: arduino/setup-task@v2
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
+          version: "3.42.1"
       - uses: dtolnay/rust-toolchain@stable
       - uses: romnn/cargo-feature-combinations@main
       - name: Doc-tests

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -21,7 +21,7 @@ jobs:
       - uses: arduino/setup-task@v2
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-          version: "v3.42.1"
+          version: "3.42.1"
       - uses: dtolnay/rust-toolchain@stable
       - uses: romnn/cargo-feature-combinations@main
       - name: Test
@@ -39,7 +39,7 @@ jobs:
       - uses: arduino/setup-task@v2
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-          version: "v3.42.1"
+          version: "3.42.1"
       - uses: dtolnay/rust-toolchain@stable
       - uses: romnn/cargo-feature-combinations@main
       - name: Doc-tests

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -912,72 +912,56 @@ dependencies = [
 name = "globetrotter-cpp"
 version = "0.0.1"
 dependencies = [
- "color-eyre",
  "serde",
- "tracing",
 ]
 
 [[package]]
 name = "globetrotter-csharp"
 version = "0.0.1"
 dependencies = [
- "color-eyre",
  "serde",
- "tracing",
 ]
 
 [[package]]
 name = "globetrotter-dart"
 version = "0.0.1"
 dependencies = [
- "color-eyre",
  "serde",
- "tracing",
 ]
 
 [[package]]
 name = "globetrotter-elixir"
 version = "0.0.1"
 dependencies = [
- "color-eyre",
  "serde",
- "tracing",
 ]
 
 [[package]]
 name = "globetrotter-golang"
 version = "0.0.1"
 dependencies = [
- "color-eyre",
  "serde",
- "tracing",
 ]
 
 [[package]]
 name = "globetrotter-java"
 version = "0.0.1"
 dependencies = [
- "color-eyre",
  "serde",
- "tracing",
 ]
 
 [[package]]
 name = "globetrotter-kotlin"
 version = "0.0.1"
 dependencies = [
- "color-eyre",
  "serde",
- "tracing",
 ]
 
 [[package]]
 name = "globetrotter-lua"
 version = "0.0.1"
 dependencies = [
- "color-eyre",
  "serde",
- "tracing",
 ]
 
 [[package]]
@@ -1005,27 +989,21 @@ dependencies = [
 name = "globetrotter-php"
 version = "0.0.1"
 dependencies = [
- "color-eyre",
  "serde",
- "tracing",
 ]
 
 [[package]]
 name = "globetrotter-python"
 version = "0.0.1"
 dependencies = [
- "color-eyre",
  "serde",
- "tracing",
 ]
 
 [[package]]
 name = "globetrotter-ruby"
 version = "0.0.1"
 dependencies = [
- "color-eyre",
  "serde",
- "tracing",
 ]
 
 [[package]]
@@ -1054,9 +1032,7 @@ dependencies = [
 name = "globetrotter-swift"
 version = "0.0.1"
 dependencies = [
- "color-eyre",
  "serde",
- "tracing",
 ]
 
 [[package]]
@@ -1080,9 +1056,7 @@ dependencies = [
 name = "globetrotter-zig"
 version = "0.0.1"
 dependencies = [
- "color-eyre",
  "serde",
- "tracing",
 ]
 
 [[package]]

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,56 +8,18 @@ RUN rustup target add x86_64-unknown-linux-musl aarch64-unknown-linux-musl
 FROM chef AS planner
 COPY ./Cargo.toml ./Cargo.lock ./
 COPY ./crates ./crates
-RUN apk add tree && tree ./
+
 RUN cargo chef prepare \
     --recipe-path ./recipe.json \
     --bin globetrotter
 
-# --package globetrotter-cli \
-
 # build
 FROM chef AS builder
-# map buildkit arch (amd64/arm64) to rust target triple
 ARG TARGETARCH
 
-# RUN set -eux; \
-#     case "${TARGETARCH}" in \
-#       amd64) export RUST_TARGET_TRIPLE=x86_64-unknown-linux-musl;; \
-#       arm64) export RUST_TARGET_TRIPLE=aarch64-unknown-linux-musl;; \
-#       *) echo "unsupported arch ${TARGETARCH}" >&2; exit 1;; \
-#     esac;
-
-# map buildkit arch (amd64/arm64) to rust target triple
-# ARG TARGETARCH
-# ARG RUST_TARGET_TRIPLE
-#
-# RUN set -eux; \
-#     case "${TARGETARCH}" in \
-#       amd64) echo "RUST_TARGET_TRIPLE=x86_64-unknown-linux-musl" >> /tmp/rt.env;; \
-#       arm64) echo "RUST_TARGET_TRIPLE=aarch64-unknown-linux-musl" >> /tmp/rt.env;; \
-#       *) exit 1;; \
-#     esac;
-#
-# # then load & persist it
-# RUN --mount=type=bind,source=/tmp/rt.env,target=/tmp/rt.env \
-#     eval "$(cat /tmp/rt.env)" && \
-#     echo "ENV RUST_TARGET_TRIPLE=${RUST_TARGET_TRIPLE}" >> /usr/local/env-vars
-#
-# # Now actually set the ENV for following layers
-# ENV RUST_TARGET_TRIPLE="${RUST_TARGET_TRIPLE}"
-#
-# RUN echo "${TARGETARCH} => ${RUST_TARGET_TRIPLE}"
-
-# install musl and add the musl targets
 RUN apk add --no-cache musl-dev
-# RUN apt-get update \
-#  && apt-get install -y --no-install-recommends musl-tools \
-#  && rustup target add x86_64-unknown-linux-musl aarch64-unknown-linux-musl \
-#  && rm -rf /var/lib/apt/lists/*
 
-# WORKDIR /app
 COPY --from=planner /app/recipe.json ./recipe.json
-# RUN cargo chef cook --release --recipe-path ./recipe.json --bin "$BIN_NAME"
 RUN --mount=type=cache,target=/usr/local/cargo/registry \
     --mount=type=cache,target=/app/target \
     set -eux; \
@@ -67,11 +29,6 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry \
 	    amd64) echo x86_64-unknown-linux-musl;; \
 	    arm64) echo aarch64-unknown-linux-musl;; \
 	esac)
-	# --package globetrotter-cli \
-	# --bin globetrotter
-
-# --package globetrotter-cli \
-# --target "${RUST_TARGET_TRIPLE}" \
 
 # now copy full source and build the actual binary
 COPY . .
@@ -89,77 +46,6 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry \
 	--package globetrotter-cli \
 	--bin globetrotter \
     && mv /app/target/${RUST_TARGET_TRIPLE}/debug/globetrotter /app/globetrotter
-
-# --release 
-
-# --target $(case "${TARGETARCH}" in \
-#     amd64) echo x86_64-unknown-linux-musl;; \
-#     arm64) echo aarch64-unknown-linux-musl;; \
-# esac) \
- #    RUN set -eux; \
-	# && /app/target/${RUST_TARGET_TRIPLE}/release/globetrotter /app/globetrotter
-
-# --package globetrotter-cli \
-# --target "${RUST_TARGET_TRIPLE}" \
-
-# # map buildkit arch (amd64/arm64) to rust target triple
-# ARG TARGETARCH
-# RUN set -eux; \
-#     case "${TARGETARCH}" in \
-#       amd64) export RUST_TARGET_TRIPLE=x86_64-unknown-linux-musl;; \
-#       arm64) export RUST_TARGET_TRIPLE=aarch64-unknown-linux-musl;; \
-#       *) echo "unsupported arch ${TARGETARCH}" >&2; exit 1;; \
-#     esac && ls -liah /app/target/ && mv /app/target/${RUST_TARGET_TRIPLE}/release/globetrotter /app/globetrotter
-
-# RUN mv /app/target/${RUST_TARGET_TRIPLE}/release/globetrotter /app/globetrotter
-
-# copy in our dependency‐only recipe
-# COPY --from=chef /usr/src/app/recipe.json recipe.json
-
-# FROM rust:1.86 AS chef
-# WORKDIR /usr/src/app
-#
-# # install cargo-chef
-# RUN cargo install cargo-chef --locked
-#
-# # copy just the manifest(s) for recipe generation
-# COPY Cargo.toml Cargo.lock ./
-#
-# # create a recipe.json that describes your dependency graph
-# RUN cargo chef prepare --recipe-path recipe.json
-#
-# ###############################################################################
-# # 2) “Build” stage: compile dependencies for the target arch
-# ###############################################################################
-# FROM rust:1.74 AS builder
-# # allow buildkit to pass TARGETARCH (e.g. x86_64 or aarch64)
-# ARG TARGETARCH
-#
-# # install musl and add the musl targets
-# RUN apt-get update \
-#  && apt-get install -y --no-install-recommends musl-tools \
-#  && rustup target add x86_64-unknown-linux-musl aarch64-unknown-linux-musl \
-#  && rm -rf /var/lib/apt/lists/*
-#
-# WORKDIR /usr/src/app
-#
-# # copy in our dependency‐only recipe
-# COPY --from=chef /usr/src/app/recipe.json recipe.json
-#
-# # build just the deps into cache (cached by recipe.json + TARGETARCH)
-# RUN --mount=type=cache,target=/usr/local/cargo/registry \
-#     --mount=type=cache,target=/usr/src/app/target \
-#     cargo chef cook --release \
-#       --target ${TARGETARCH}-unknown-linux-musl \
-#       --recipe-path recipe.json
-#
-# # now copy your full source and build the actual binary
-# COPY . .
-#
-# RUN --mount=type=cache,target=/usr/local/cargo/registry \
-#     --mount=type=cache,target=/usr/src/app/target \
-#     cargo build --release \
-#       --target ${TARGETARCH}-unknown-linux-musl
 
 # runtime
 FROM scratch AS runtime

--- a/crates/globetrotter-cpp/Cargo.toml
+++ b/crates/globetrotter-cpp/Cargo.toml
@@ -35,5 +35,3 @@ rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
 serde.workspace = true
-color-eyre.workspace = true
-tracing.workspace = true

--- a/crates/globetrotter-csharp/Cargo.toml
+++ b/crates/globetrotter-csharp/Cargo.toml
@@ -35,5 +35,3 @@ rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
 serde.workspace = true
-color-eyre.workspace = true
-tracing.workspace = true

--- a/crates/globetrotter-dart/Cargo.toml
+++ b/crates/globetrotter-dart/Cargo.toml
@@ -35,5 +35,3 @@ rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
 serde.workspace = true
-color-eyre.workspace = true
-tracing.workspace = true

--- a/crates/globetrotter-elixir/Cargo.toml
+++ b/crates/globetrotter-elixir/Cargo.toml
@@ -35,5 +35,3 @@ rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
 serde.workspace = true
-color-eyre.workspace = true
-tracing.workspace = true

--- a/crates/globetrotter-golang/Cargo.toml
+++ b/crates/globetrotter-golang/Cargo.toml
@@ -35,5 +35,3 @@ rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
 serde.workspace = true
-color-eyre.workspace = true
-tracing.workspace = true

--- a/crates/globetrotter-java/Cargo.toml
+++ b/crates/globetrotter-java/Cargo.toml
@@ -35,5 +35,3 @@ rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
 serde.workspace = true
-color-eyre.workspace = true
-tracing.workspace = true

--- a/crates/globetrotter-kotlin/Cargo.toml
+++ b/crates/globetrotter-kotlin/Cargo.toml
@@ -35,5 +35,3 @@ rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
 serde.workspace = true
-color-eyre.workspace = true
-tracing.workspace = true

--- a/crates/globetrotter-lua/Cargo.toml
+++ b/crates/globetrotter-lua/Cargo.toml
@@ -35,5 +35,3 @@ rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
 serde.workspace = true
-color-eyre.workspace = true
-tracing.workspace = true

--- a/crates/globetrotter-php/Cargo.toml
+++ b/crates/globetrotter-php/Cargo.toml
@@ -35,5 +35,3 @@ rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
 serde.workspace = true
-color-eyre.workspace = true
-tracing.workspace = true

--- a/crates/globetrotter-python/Cargo.toml
+++ b/crates/globetrotter-python/Cargo.toml
@@ -35,5 +35,3 @@ rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
 serde.workspace = true
-color-eyre.workspace = true
-tracing.workspace = true

--- a/crates/globetrotter-ruby/Cargo.toml
+++ b/crates/globetrotter-ruby/Cargo.toml
@@ -35,5 +35,3 @@ rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
 serde.workspace = true
-color-eyre.workspace = true
-tracing.workspace = true

--- a/crates/globetrotter-swift/Cargo.toml
+++ b/crates/globetrotter-swift/Cargo.toml
@@ -35,5 +35,3 @@ rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
 serde.workspace = true
-color-eyre.workspace = true
-tracing.workspace = true

--- a/crates/globetrotter-zig/Cargo.toml
+++ b/crates/globetrotter-zig/Cargo.toml
@@ -35,5 +35,3 @@ rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
 serde.workspace = true
-color-eyre.workspace = true
-tracing.workspace = true

--- a/docker/build_from_source.dockerfile
+++ b/docker/build_from_source.dockerfile
@@ -15,15 +15,17 @@ RUN cargo chef prepare \
 
 # build
 FROM chef AS builder
-ARG TARGETARCH
 
 RUN apk add --no-cache musl-dev
 
 COPY --from=planner /app/recipe.json ./recipe.json
+ARG TARGETARCH
+
 RUN --mount=type=cache,target=/usr/local/cargo/registry \
     --mount=type=cache,target=/app/target \
     set -eux; \
     cargo chef cook \
+	--release \
 	--recipe-path ./recipe.json \
 	--target $(case "${TARGETARCH}" in \
 	    amd64) echo x86_64-unknown-linux-musl;; \
@@ -42,10 +44,11 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry \
       *) exit 1;; \
     esac; \
     cargo build \
+	--release \
 	--target "${RUST_TARGET_TRIPLE}" \
 	--package globetrotter-cli \
 	--bin globetrotter \
-    && mv /app/target/${RUST_TARGET_TRIPLE}/debug/globetrotter /app/globetrotter
+    && mv /app/target/${RUST_TARGET_TRIPLE}/release/globetrotter /app/globetrotter
 
 # runtime
 FROM scratch AS runtime

--- a/docker/package_precompiled.dockerfile
+++ b/docker/package_precompiled.dockerfile
@@ -1,4 +1,4 @@
-FROM scratch
+FROM busybox AS package
 
 COPY ./goreleaser-dist /tmp/goreleaser-dist
 
@@ -9,8 +9,10 @@ RUN set -eux; \
       arm64) export RUST_TARGET_TRIPLE=aarch64-unknown-linux-musl;; \
       *) exit 1;; \
     esac; \
-    cp /tmp/goreleaser-dist/globetrotter_${RUST_TARGET_TRIPLE}/globetrotter \
-	/usr/local/bin/globetrotter \
-    && rm -rf /tmp/goreleaser-dist
+    ls -liah /tmp/goreleaser-dist/ \
+    && cp /tmp/goreleaser-dist/globetrotter_${RUST_TARGET_TRIPLE}/globetrotter \
+	/usr/bin/globetrotter \
 
+FROM scratch
+COPY --from=package /usr/bin/globetrotter /usr/local/bin/globetrotter
 ENTRYPOINT ["/usr/local/bin/globetrotter"]

--- a/docker/package_precompiled.dockerfile
+++ b/docker/package_precompiled.dockerfile
@@ -11,7 +11,7 @@ RUN set -eux; \
     esac; \
     ls -liah /tmp/goreleaser-dist/ \
     && cp /tmp/goreleaser-dist/globetrotter_${RUST_TARGET_TRIPLE}/globetrotter \
-	/usr/bin/globetrotter \
+	/usr/bin/globetrotter
 
 FROM scratch
 COPY --from=package /usr/bin/globetrotter /usr/local/bin/globetrotter

--- a/docker/package_precompiled.dockerfile
+++ b/docker/package_precompiled.dockerfile
@@ -1,0 +1,16 @@
+FROM scratch
+
+COPY ./goreleaser-dist /tmp/goreleaser-dist
+
+ARG TARGETARCH
+RUN set -eux; \
+    case "${TARGETARCH}" in \
+      amd64) export RUST_TARGET_TRIPLE=x86_64-unknown-linux-musl;; \
+      arm64) export RUST_TARGET_TRIPLE=aarch64-unknown-linux-musl;; \
+      *) exit 1;; \
+    esac; \
+    cp /tmp/goreleaser-dist/globetrotter_${RUST_TARGET_TRIPLE}/globetrotter \
+	/usr/local/bin/globetrotter \
+    && rm -rf /tmp/goreleaser-dist
+
+ENTRYPOINT ["/usr/local/bin/globetrotter"]

--- a/taskfile.yaml
+++ b/taskfile.yaml
@@ -34,7 +34,7 @@ tasks:
         -v "${PWD}:/workspace"
         -w /workspace
         ghcr.io/rust-cross/cargo-zigbuild
-        bash -c './release.sh && goreleaser build --snapshot --clean'
+        bash -c './release.sh && goreleaser build --snapshot --clean --timeout 120m'
 
   build:container:
     desc: "build multi-arch docker container from source"
@@ -60,7 +60,7 @@ tasks:
         -v "${PWD}:/workspace"
         -w /workspace
         ghcr.io/rust-cross/cargo-zigbuild
-        bash -c './release.sh && goreleaser release --clean'
+        bash -c './release.sh && goreleaser release --clean --timeout 120m'
 
   typos:
     desc: "check repository for typos"

--- a/taskfile.yaml
+++ b/taskfile.yaml
@@ -26,7 +26,7 @@ tasks:
       - cargo build --all-targets --release {{.CLI_ARGS}}
 
   build:goreleaser:
-    desc: "build in release mode using goreleaser"
+    desc: "cross compile using goreleaser"
     cmds:
       # pretter-ignore
       - >-
@@ -37,14 +37,14 @@ tasks:
         bash -c './release.sh && goreleaser build --snapshot --clean'
 
   build:container:
-    desc: "build multi-arch docker container"
+    desc: "build multi-arch docker container from source"
     cmds:
       # pretter-ignore
       - >-
         docker buildx build
         --load
         --platform linux/amd64,linux/arm64
-        -f ./Dockerfile
+        -f ./docker/build_from_source.dockerfile
         -t globetrotter:latest
         ./
         {{.CLI_ARGS}}


### PR DESCRIPTION
This PR adds two ways of building a docker image for `globetrotter`:

- `docker/build_from_source.dockerfile` builds a multi-arch image (linux arm64/amd64) from source using docker emulation (via --platform), which takes very long.
- `package_precompiled.dockerfile` simply packages the cross-compiled binaries created using goreleaser, which is much faster.

Right now, the second approach is used in CI.